### PR TITLE
Add token support for NapCat HTTP API authentication

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,10 +1,14 @@
 // Minimal NapCat Channel Implementation
 import { setNapCatConfig } from "./runtime.js";
 
-async function sendToNapCat(url: string, payload: any) {
+async function sendToNapCat(url: string, payload: any, token?: string) {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+    }
     const res = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(payload)
     });
     if (!res.ok) {
@@ -156,6 +160,12 @@ export const napcatPlugin = {
                 title: "Inbound Log Directory",
                 description: "Directory to store per-user/per-group inbound logs",
                 default: "./logs/napcat-inbound"
+            },
+            token: {
+                type: "string",
+                title: "HTTP API Token",
+                description: "Token for authenticating with NapCat HTTP server (Bearer token)",
+                default: ""
             }
         }
     },
@@ -179,6 +189,7 @@ export const napcatPlugin = {
         sendText: async ({ to, text, cfg }: any) => {
             const config = cfg.channels?.napcat || {};
             const baseUrl = config.url || "http://127.0.0.1:3000";
+            const token = config.token || "";
             
             let targetType = "private";
             let targetId = to;
@@ -211,7 +222,7 @@ export const napcatPlugin = {
             console.log(`[NapCat] Sending to ${targetType} ${targetId}: ${text}`);
             
             try {
-                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload);
+                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload, token);
                 return { ok: true, result };
             } catch (err: any) {
                 return { ok: false, error: err.message };
@@ -220,6 +231,7 @@ export const napcatPlugin = {
         sendMedia: async ({ to, text, mediaUrl, cfg }: any) => {
             const config = cfg.channels?.napcat || {};
             const baseUrl = config.url || "http://127.0.0.1:3000";
+            const token = config.token || "";
 
             let targetType = "private";
             let targetId = to;
@@ -255,7 +267,7 @@ export const napcatPlugin = {
             console.log(`[NapCat] Sending media to ${targetType} ${targetId}: ${message}`);
 
             try {
-                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload);
+                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload, token);
                 return { ok: true, result };
             } catch (err: any) {
                 return { ok: false, error: err.message };


### PR DESCRIPTION
## Description

Add token support for authenticating with NapCat HTTP server.

## Changes

- Add `token` config option for OpenClaw configuration
- Add Bearer token to Authorization header when sending messages to NapCat
- Add token field to configSchema

## Note

Webhook token verification was not included because NapCat's HTTP client doesn't support custom Authorization headers. The token is only used when OpenClaw sends messages TO NapCat.

## Example configuration

```json
{
  "channels": {
    "napcat": {
      "enabled": true,
      "url": "http://10.1.1.50:3000",
      "token": "your-token-here",
      "allowUsers": ["2250795018"],
      "enableGroupMessages": true,
      "groupMentionOnly": true
    }
  }
}
```