### PR TITLE
fix: 调整HTTP WebHook的导入方式，兼容OpenClaw 2026.3.2+版本

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,12 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setNapCatRuntime(api.runtime);
     api.registerChannel({ plugin: napcatPlugin as any });
-    api.registerHttpHandler(handleNapCatWebhook);
+    try {
+      api.registerHttpHandler(handleNapCatWebhook);
+    } catch (error) {
+      api.logger.info("Failed to call api.registerHttpHandler, may be unsupported in this OpenClaw version:", error);
+      api.registerHttpRoute({ path: "/napcat", handler: handleNapCatWebhook, auth: "gateway", match: "exact" });
+    }
   },
 };
 


### PR DESCRIPTION
OpenClaw 2026.3.2 把之前用的 `api.registerHttpHandler` 删掉了，要求一定要使用 `api.registerHttpRoute` ，所以修改了一下调用方式，别的地方没有变化。