### PR TITLE
feat: 增加 NapCat 流式回复模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ openclaw plugins install /Users/yourname/Documents/openclaw-napcat-plugin
     "napcat": {
       "enabled": true,
       "url": "http://127.0.0.1:3000",
+      "streaming_mode": false,
       "enableGroupMessages": true,
       "groupMentionOnly": true
     }
@@ -144,6 +145,7 @@ openclaw plugins install /Users/yourname/Documents/openclaw-napcat-plugin
 
 - 启用 `napcat` 通道
 - NapCat 的 HTTP 服务地址是 `http://127.0.0.1:3000`
+- `streaming_mode` 为 `true` 时会改成流式回复，每处理一步就发一条 QQ 消息
 - 允许处理群消息
 - 但群里必须 **@ 机器人** 才会回复
 
@@ -620,6 +622,7 @@ node skill/napcat-qq/scripts/qq-contact-search.js 老王 private
 | `agentId` | string | 固定把消息交给哪个 OpenClaw agent 处理 | `""` |
 | `allowUsers` | string[] | 只允许这些 QQ 号触发机器人；空数组表示不过滤 | `[]` |
 | `enableGroupMessages` | boolean | 是否处理群消息 | `false` |
+| `streaming_mode` | boolean | 是否启用流式传输模式；开启后会按处理步骤连续发送 QQ 消息 | `false` |
 | `groupMentionOnly` | boolean | 群里是否必须 @ 机器人才处理 | `true` |
 | `mediaProxyEnabled` | boolean | 是否开启媒体代理，解决跨机器图片/语音发送问题 | `false` |
 | `publicBaseUrl` | string | OpenClaw 对 NapCat 可访问的地址 | `""` |

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -117,7 +117,11 @@ export const napcatPlugin = {
     capabilities: {
         chatTypes: ["direct", "group"],
         text: true,
-        media: true
+        media: true,
+        blockStreaming: true
+    },
+    streaming: {
+        blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 }
     },
     messaging: {
         normalizeTarget: normalizeNapCatTarget,
@@ -147,6 +151,12 @@ export const napcatPlugin = {
                 type: "boolean",
                 title: "Enable Group Messages",
                 description: "When enabled, process group messages (requires mention to trigger)",
+                default: false
+            },
+            streaming_mode: {
+                type: "boolean",
+                title: "Streaming Mode",
+                description: "Stream replies as incremental QQ messages instead of waiting for the final combined response",
                 default: false
             },
             groupMentionOnly: {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -14,6 +14,10 @@ function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isNapCatStreamingModeEnabled(config: any): boolean {
+    return config?.streaming_mode === true;
+}
+
 const napcatHttpAgent = new HttpAgent({
     keepAlive: true,
     keepAliveMsecs: 10000,
@@ -570,6 +574,8 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
 
             // Create dispatcher for replies
             let dispatcher = null;
+            let dispatcherReplyOptions: Record<string, unknown> = {};
+            let markDispatchIdle: (() => void) | null = null;
             
             // Store conversationId for reply routing
             const replyTarget = conversationId;
@@ -613,6 +619,8 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                     onIdle: () => {},
                 });
                 dispatcher = result.dispatcher;
+                dispatcherReplyOptions = result.replyOptions || {};
+                markDispatchIdle = result.markDispatchIdle || null;
             } else if (runtime.channel.reply.createReplyDispatcher) {
                 dispatcher = runtime.channel.reply.createReplyDispatcher({
                     responsePrefix: "",
@@ -661,12 +669,19 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             console.log("[NapCat] Dispatcher created, methods:", Object.keys(dispatcher));
 
             // Dispatch the message to OpenClaw
-            await runtime.channel.reply.dispatchReplyFromConfig({
-                ctx: ctxPayload,
-                cfg,
-                dispatcher,
-                replyOptions: {},
-            });
+            try {
+                await runtime.channel.reply.dispatchReplyFromConfig({
+                    ctx: ctxPayload,
+                    cfg,
+                    dispatcher,
+                    replyOptions: {
+                        ...dispatcherReplyOptions,
+                        disableBlockStreaming: !isNapCatStreamingModeEnabled(config),
+                    },
+                });
+            } finally {
+                markDispatchIdle?.();
+            }
             
             res.statusCode = 200;
             res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
## 变更说明
- 新增 channels.napcat.streaming_mode 配置项
- 开启后允许 NapCat 通道使用 OpenClaw block streaming，按处理步骤持续发送 QQ 消息
- 补充 README 中的配置示例和说明

## 验证
- 本仓库暂无可直接运行的自动化测试脚本
- 已完成代码链路自检，确认 streaming_mode 会映射到 dispatchReplyFromConfig 的 block streaming 开关