### PR TITLE
[codex] 修复 NapCat channel 生命周期退出重启

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -80,6 +80,21 @@ function isNapCatGroupFileCandidate(mediaUrl: string): boolean {
     return true;
 }
 
+function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<void> {
+    return new Promise((resolve) => {
+        const complete = () => {
+            onAbort?.();
+            resolve();
+        };
+        if (!signal) return;
+        if (signal.aborted) {
+            complete();
+            return;
+        }
+        signal.addEventListener("abort", complete, { once: true });
+    });
+}
+
 function normalizeNapCatTarget(raw: string): string {
     const trimmed = raw.trim();
     if (!trimmed) return trimmed;
@@ -426,9 +441,13 @@ export const napcatPlugin = {
         },
     },
     gateway: {
-        startAccount: async () => {
-             console.log("[NapCat] Plugin active. Listening on /napcat");
-             return { stop: () => {} };
+        startAccount: async (ctx?: any) => {
+            ctx?.log?.info?.("NapCat plugin active. Listening on /napcat");
+            console.log("[NapCat] Plugin active. Listening on /napcat");
+            return waitUntilAbort(ctx?.abortSignal, () => {
+                ctx?.log?.info?.("NapCat plugin stopped");
+                console.log("[NapCat] Plugin stopped");
+            });
         }
     }
 };


### PR DESCRIPTION
## 背景

用户反馈安装 NapCat 插件后，OpenClaw gateway 会持续打印 channel 正常退出并自动重启：

```text
[napcat] [default] channel exited without an error
[napcat] [default] auto-restart attempt 1/10 in 5s
```

## 根因

`startAccount` 启动 NapCat channel 后很快 resolve，导致 OpenClaw 的 channel supervisor 认为该 channel 已经退出。supervisor 随后按预期触发自动重启，于是形成反复退出和重启的日志循环。

## 修改

- 让 NapCat channel 的生命周期等待 `ctx.abortSignal`。
- 只有 gateway 主动停止或 channel 被中止时，`startAccount` 才会结束。
- 保留原有 stop 行为，并在 abort 后清理监听器。

## 影响

修复后，NapCat channel 不会在启动成功后立即被 OpenClaw 判定为退出，可以避免自动重启循环，以及由重启带来的回复丢失或 gateway 不稳定。

## 验证

- `git diff --check`
- `npm_config_cache=/private/tmp/openclaw-napcat-npm-cache npm pack --dry-run`
- 本地打包安装后验证：OpenClaw 能接收 NapCat 上报并生成回复；修正 NapCat Docker HTTP Server 暴露配置后，回复可正常发送回 NapCat。
- 观察 gateway 日志，未再出现 `channel exited without an error` / `auto-restart attempt` 循环。