### PR TITLE
chore: 发布 1.0.3

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "napcat",
   "name": "NapCat QQ",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "author": "ProperSAMA",
   "channels": ["napcat"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "type": "module",


### PR DESCRIPTION
## 修改

- 将 npm 包版本从 `1.0.2` 提升到 `1.0.3`。
- 同步 `openclaw.plugin.json` 的插件版本号到 `1.0.3`。

## 验证

- `git diff --check`
- `npm_config_cache=/private/tmp/openclaw-napcat-npm-cache npm pack --dry-run`

## 备注

`master` 是保护分支，版本提交需要通过 PR 合并。npm 发布将在 npm 登录态恢复后继续执行。