### PR TITLE
[codex] 发布 1.0.4

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "napcat",
   "name": "NapCat QQ",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "author": "ProperSAMA",
   "channels": ["napcat"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "devDependencies": {
         "@types/node": "^22.15.3",
         "openclaw": "^2026.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "type": "module",


### PR DESCRIPTION
## 背景

准备发布包含 #30 安装修复的 npm patch 版本。

## 改动

- 将 `package.json` 版本从 `1.0.3` 更新到 `1.0.4`。
- 同步更新 `package-lock.json` 根包版本。
- 同步更新 `openclaw.plugin.json` manifest 版本。

## 验证

- `npm run build`
- `npm --cache /tmp/openclaw-napcat-npm-cache pack --dry-run`
- 本机 OpenClaw 2026.5.4 临时 HOME 安装 `propersama-openclaw-napcat-1.0.4.tgz` 成功。
- `openclaw plugins list` 显示 `NapCat QQ` enabled，版本为 `1.0.4`，source 指向 `dist/index.js`，没有 config warning。

## 发布状态

npm 发布尚未执行：当前本机 npm registry 登录态失效，`npm whoami` 返回 401。合并后需要重新登录 npm 再执行 `npm publish --access public`。