### PR TITLE
fix: 避免 NapCat 回复分发错误返回 500

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -973,15 +973,23 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             // Dispatch the message to OpenClaw
             try {
                 await typingController.start();
-                await runtime.channel.reply.dispatchReplyFromConfig({
-                    ctx: ctxPayload,
-                    cfg,
-                    dispatcher,
-                    replyOptions: {
-                        ...dispatcherReplyOptions,
-                        disableBlockStreaming: !isNapCatStreamingModeEnabled(config),
-                    },
-                });
+                try {
+                    await runtime.channel.reply.dispatchReplyFromConfig({
+                        ctx: ctxPayload,
+                        cfg,
+                        dispatcher,
+                        replyOptions: {
+                            ...dispatcherReplyOptions,
+                            disableBlockStreaming: !isNapCatStreamingModeEnabled(config),
+                        },
+                    });
+                } catch (err) {
+                    console.error("[NapCat] Reply dispatch failed (acknowledged to avoid NapCat webhook retry):", err);
+                    res.statusCode = 200;
+                    res.setHeader("Content-Type", "application/json");
+                    res.end('{"status":"ok","message":"reply dispatch failed"}');
+                    return true;
+                }
             } finally {
                 typingController.stop();
                 markDispatchIdle?.();


### PR DESCRIPTION
## Summary
- acknowledge reply dispatch failures with HTTP 200 so NapCat does not treat the webhook report as failed
- keep logging the dispatch error for diagnosis
- still leave outer handler errors as HTTP 500 for structural webhook failures

## Root Cause
OpenClaw can reject a reply dispatch when the same session is already initializing, e.g. `reply session initialization conflicted ...`. The plugin previously let that error fall through to the outer catch, returning HTTP 500 to NapCat.

## Validation
- npm run build