### PR TITLE
feat: 让 NapCat agent 感知自身 QQ 号

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,27 @@ node skill/napcat-qq/scripts/qq-contact-search.js 老王 private
 
 ---
 
+### Agent 怎么知道自己用的是哪个 QQ 号
+
+NapCat 入站事件会带上机器人自己的 QQ 号（`self_id`）。插件会优先使用这个值，缺失时回退到配置里的 `selfId`。
+
+在交给 OpenClaw agent 的当前消息上下文里，插件会提供这些字段：
+
+- `SelfId`
+- `BotId`
+- `BotQQ`
+- `NapCatSelfId`
+
+同时，模型可见的 `BodyForAgent` 会在原消息前追加一行：
+
+```text
+[NapCat context: bot QQ=<机器人QQ号>]
+```
+
+这样 agent 在同一个 QQ 群里处理消息时，也能明确知道“我现在是哪个 QQ 号”。
+
+---
+
 ### 如果想按群路由到不同 agent
 
 现在 NapCat 插件会把会话信息作为 `peer` 传给 OpenClaw 的路由器，你可以在 `openclaw.json` 里用 `bindings` 为特定群指定 agent：

--- a/skill/napcat-qq/SKILL.md
+++ b/skill/napcat-qq/SKILL.md
@@ -36,6 +36,11 @@ description: "为 openclaw 发送 QQ 消息（含图片/语音等媒体）时，
 
 9. 仅使用本插件的 API 完成发送，不要调用其他 QQ 发送途径。
 
+# 入站上下文
+
+- 当消息来自 NapCat 入站通道时，当前上下文会提供机器人自己的 QQ 号字段：`SelfId`、`BotId`、`BotQQ`、`NapCatSelfId`。
+- 模型可见正文 `BodyForAgent` 会带有 `[NapCat context: bot QQ=<机器人QQ号>]` 前缀；需要判断“我现在用的是哪个 QQ 号”时优先读取这些上下文，不要猜。
+
 # 交互规则
 
 - 若用户未提供 QQ 号或群号，优先尝试用昵称/备注/群名搜索；搜索无结果时再询问并明确补全后发送。

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -666,6 +666,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             const groupId = isGroup ? String(event.group_id || "") : "";
             // Ensure senderId is numeric string
             const senderId = String(event.user_id);
+            const botId = String(event.self_id || config.selfId || "").trim();
             // Safety check: if senderId looks like a name (non-numeric), log warning
             if (!/^\d+$/.test(senderId)) {
                 console.warn(`[NapCat] WARNING: user_id is not numeric: ${senderId}`);
@@ -714,7 +715,6 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                     return true;
                 }
 
-                const botId = event.self_id || config.selfId;
                 if (groupMentionOnly) {
                     // Check if bot was mentioned
                     // NapCat sends self_id as the bot's QQ number
@@ -824,6 +824,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
 
             // User requested to use session key as display name for consistency
             const sessionDisplayName = sessionKey;
+            const bodyForAgent = botId ? `[NapCat context: bot QQ=${botId}]\n${text}` : text;
 
             // Log for debugging
             console.log(`[NapCat] Inbound from ${senderId} (session: ${sessionKey}): ${text.substring(0, 50)}...`);
@@ -838,6 +839,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             // Build ctxPayload using runtime methods
             const ctxPayload = {
                 Body: text,
+                BodyForAgent: bodyForAgent,
                 RawBody: rawText,
                 CommandBody: text,
                 From: `napcat:${conversationId}`,
@@ -855,6 +857,10 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                 ConversationLabel: sessionKey,
                 SenderName: senderName,
                 SenderId: senderId,
+                SelfId: botId,
+                BotId: botId,
+                BotQQ: botId,
+                NapCatSelfId: botId,
                 Provider: "napcat",
                 Surface: "napcat",
                 MessageSid: messageId,


### PR DESCRIPTION
## Summary

- expose the NapCat bot/self QQ number in inbound turn context as `SelfId`, `BotId`, `BotQQ`, and `NapCatSelfId`
- add a model-visible `BodyForAgent` prefix so agents can tell which QQ account they are currently using
- document the new inbound context fields in the README and bundled `napcat-qq` skill

## Validation

- `npm run build`
- `git diff --check`
- linked the local plugin with `openclaw plugins install . --link`
- restarted the local OpenClaw Gateway
- verified `openclaw plugins doctor` reports no plugin issues
- verified `/napcat` webhook returns `HTTP 200 {"status":"ok"}` for a heartbeat probe
