### PR TITLE
chore: 发布 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "@types/node": "^22.15.3",
         "openclaw": "^2026.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `@propersama/openclaw-napcat` from `1.0.4` to `1.0.5`
- keep `package-lock.json` in sync for the patch release

## Validation

- `npm run build`
- `npm pack --dry-run --cache /tmp/openclaw-napcat-npm-cache`
- `git diff --check`

## Publish notes

After this PR is merged, publish from `master` with an npm session that can complete MFA:

```bash
npm publish --cache /tmp/openclaw-napcat-npm-cache --access public
```

If npm asks for an OTP, rerun with:

```bash
npm publish --cache /tmp/openclaw-napcat-npm-cache --access public --otp <code>
```
