### PR TITLE
fix: prevent duplicate NapCat message retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "prepack": "npm run build"
   },
   "files": [

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -151,9 +151,24 @@ async function postJsonWithNodeHttp(
     });
 }
 
-// Send message via NapCat API (node http/https keep-alive + retry for transient socket errors)
-async function sendToNapCat(url: string, payload: any, token?: string) {
-    const maxAttempts = 3;
+type SendToNapCatOptions = {
+    /**
+     * Retries are safe for reads and idempotent actions, but must be disabled
+     * for message sends: NapCat may have accepted the message even when the
+     * HTTP response is lost, and retrying would send the same message again.
+     */
+    allowRetry?: boolean;
+};
+
+// Call the NapCat API using node http/https. Transient retries are opt-out so
+// existing read/idempotent callers retain their previous behavior.
+export async function sendToNapCat(
+    url: string,
+    payload: any,
+    token?: string,
+    options: SendToNapCatOptions = {}
+) {
+    const maxAttempts = options.allowRetry === false ? 1 : 3;
     const timeoutsMs = [5000, 7000, 9000];
     const cfg = getNapCatConfig();
     const connectionClose = cfg.connectionClose !== false; // default true for local docker stability
@@ -908,7 +923,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         
                         console.log(`[NapCat] Sending reply to ${isGroup ? 'group' : 'private'} ${targetId}: ${message.substring(0, 50)}...`);
                         try {
-                            await sendToNapCat(`${baseUrl}${endpoint}`, msgPayload, token);
+                            await sendToNapCat(`${baseUrl}${endpoint}`, msgPayload, token, { allowRetry: false });
                             console.log("[NapCat] Reply sent successfully");
                         } catch (err) {
                             console.error("[NapCat] Reply delivery failed (suppressed to avoid channel crash):", err);
@@ -954,7 +969,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         
                         console.log(`[NapCat] Sending reply to ${isGroup ? 'group' : 'private'} ${targetId}: ${message.substring(0, 50)}...`);
                         try {
-                            await sendToNapCat(`${baseUrl}${endpoint}`, msgPayload, token);
+                            await sendToNapCat(`${baseUrl}${endpoint}`, msgPayload, token, { allowRetry: false });
                             console.log("[NapCat] Reply sent successfully");
                         } catch (err) {
                             console.error("[NapCat] Reply delivery failed (suppressed to avoid channel crash):", err);

--- a/tests/sendToNapCat.test.mjs
+++ b/tests/sendToNapCat.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { sendToNapCat } from "../dist/src/webhook.js";
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Test server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+test("non-idempotent message sends are not retried after a lost response", async () => {
+  let requestCount = 0;
+  const server = createServer((req) => {
+    requestCount += 1;
+    req.resume();
+    req.on("end", () => {
+      // Simulate NapCat accepting the request and sending the QQ message, then
+      // losing the HTTP response before OpenClaw can observe success.
+      req.socket.destroy();
+    });
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    await assert.rejects(
+      sendToNapCat(
+        `${baseUrl}/send_group_msg`,
+        { group_id: "123456", message: "only once" },
+        undefined,
+        { allowRetry: false },
+      ),
+    );
+    assert.equal(requestCount, 1);
+  } finally {
+    await close(server);
+  }
+});
+
+test("idempotent NapCat calls keep transient retries enabled", async () => {
+  let requestCount = 0;
+  const server = createServer((req, res) => {
+    requestCount += 1;
+    req.resume();
+    req.on("end", () => {
+      if (requestCount < 3) {
+        req.socket.destroy();
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"status":"ok","data":{"message":"retried safely"}}');
+    });
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await sendToNapCat(
+      `${baseUrl}/get_forward_msg`,
+      { message_id: "123456" },
+    );
+    assert.equal(requestCount, 3);
+    assert.equal(result.data.message, "retried safely");
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

- disable automatic retries for group and private message sends
- retain transient retries for safe/idempotent NapCat API calls
- add regression coverage for lost HTTP responses after a message is accepted

## Test

- npm test (2 tests passed)