### PR TITLE
feat: mention sender in group replies

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3,7 +3,14 @@ import path from "node:path";
 import { access, copyFile, mkdir, unlink } from "node:fs/promises";
 import { buildNapCatMediaCq, isAudioMedia, resolveLocalFilePath } from "./media.js";
 import { formatNapCatOutgoingText } from "./plainText.js";
-import { setNapCatConfig } from "./runtime.js";
+import { getNapCatGroupReplyMentionUser, setNapCatConfig } from "./runtime.js";
+
+const recentTextDeliveries = new Map<string, {
+    expiresAt: number;
+    promise: Promise<any>;
+}>();
+const RECENT_TEXT_DELIVERY_TTL_MS = 15_000;
+let fallbackMessageIdSequence = 0;
 
 async function sendToNapCat(url: string, payload: any, token?: string) {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -26,6 +33,72 @@ async function sendToNapCat(url: string, payload: any, token?: string) {
         throw new Error(`NapCat API Error: ${res.status} ${res.statusText}${body ? ` | body=${body}` : ""}`);
     }
     return await res.json();
+}
+
+function withActiveGroupMention(message: string, targetType: string, targetId: string): string {
+    if (targetType !== "group" || !message) return message;
+    const mentionUserId = getNapCatGroupReplyMentionUser(targetId);
+    if (!mentionUserId) return message;
+    const mention = `[CQ:at,qq=${mentionUserId}]`;
+    if (message.includes(mention)) return message;
+    return `${mention} ${message}`;
+}
+
+function resolveNapCatMessageId(result: any): string {
+    const candidates = [
+        result?.data?.message_id,
+        result?.data?.messageId,
+        result?.message_id,
+        result?.messageId,
+        result?.data?.file_id,
+        result?.data?.fileId,
+        result?.echo,
+    ];
+    for (const candidate of candidates) {
+        if (candidate !== undefined && candidate !== null && String(candidate).trim()) {
+            return String(candidate);
+        }
+    }
+    fallbackMessageIdSequence += 1;
+    return `napcat-ack-${Date.now()}-${fallbackMessageIdSequence}`;
+}
+
+function toOutboundDeliveryResult(result: any, targetId: string) {
+    return {
+        channel: "napcat",
+        messageId: resolveNapCatMessageId(result),
+        chatId: targetId,
+    };
+}
+
+async function sendTextToNapCatOnce(
+    url: string,
+    payload: any,
+    token: string,
+    deliveryKey: string,
+) {
+    const now = Date.now();
+    for (const [key, entry] of recentTextDeliveries) {
+        if (entry.expiresAt <= now) recentTextDeliveries.delete(key);
+    }
+
+    const existing = recentTextDeliveries.get(deliveryKey);
+    if (existing && existing.expiresAt > now) {
+        console.warn(`[NapCat] Suppressed duplicate outbound delivery: ${deliveryKey.split("\u0000").slice(0, 2).join(" ")}`);
+        return existing.promise;
+    }
+
+    const promise = sendToNapCat(url, payload, token);
+    recentTextDeliveries.set(deliveryKey, {
+        expiresAt: now + RECENT_TEXT_DELIVERY_TTL_MS,
+        promise,
+    });
+    try {
+        return await promise;
+    } catch (err) {
+        recentTextDeliveries.delete(deliveryKey);
+        throw err;
+    }
 }
 
 async function uploadGroupFileToNapCat(url: string, payload: {
@@ -320,19 +393,25 @@ export const napcatPlugin = {
             }
 
             const endpoint = targetType === "group" ? "/send_group_msg" : "/send_private_msg";
-            const message = formatNapCatOutgoingText(text, config);
+            const message = withActiveGroupMention(
+                formatNapCatOutgoingText(text, config),
+                targetType,
+                targetId,
+            );
             const payload: any = { message };
             if (targetType === "group") payload.group_id = targetId;
             else payload.user_id = targetId;
 
             console.log(`[NapCat] Sending to ${targetType} ${targetId}: ${message}`);
             
-            try {
-                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload, token);
-                return { ok: true, result };
-            } catch (err: any) {
-                return { ok: false, error: err.message };
-            }
+            const deliveryKey = `${endpoint}\u0000${targetId}\u0000${message}`;
+            const result = await sendTextToNapCatOnce(
+                `${baseUrl}${endpoint}`,
+                payload,
+                token,
+                deliveryKey,
+            );
+            return toOutboundDeliveryResult(result, targetId);
         },
         sendMedia: async ({ to, text, mediaUrl, cfg }: any) => {
             const config = cfg.channels?.napcat || {};
@@ -397,7 +476,11 @@ export const napcatPlugin = {
                     })}`);
                     const uploadResult = await uploadGroupFileToNapCat(`${baseUrl}/upload_group_file`, uploadPayload, token);
 
-                    const plainText = formatNapCatOutgoingText(text || "", config);
+                    const plainText = withActiveGroupMention(
+                        formatNapCatOutgoingText(text || "", config),
+                        targetType,
+                        targetId,
+                    );
                     if (plainText && plainText.trim()) {
                         await sendToNapCat(`${baseUrl}${endpoint}`, {
                             group_id: targetId,
@@ -406,9 +489,9 @@ export const napcatPlugin = {
                     }
 
                     console.log(`[NapCat] Uploaded group file to ${targetId}: ${localFilePath}`);
-                    return { ok: true, result: uploadResult };
+                    return toOutboundDeliveryResult(uploadResult, targetId);
                 } catch (err: any) {
-                    return { ok: false, error: err.message };
+                    throw err;
                 } finally {
                     if (stagedPath) {
                         try {
@@ -432,9 +515,10 @@ export const napcatPlugin = {
                 ? await buildNapCatMediaCq(mediaUrl, config)
                 : "";
             const plainText = formatNapCatOutgoingText(text || "", config);
-            const message = plainText
+            const messageWithoutMention = plainText
                 ? (mediaMessage ? `${plainText}\n${mediaMessage}` : plainText)
                 : (mediaMessage || "");
+            const message = withActiveGroupMention(messageWithoutMention, targetType, targetId);
 
             const payload: any = { message };
             if (targetType === "group") payload.group_id = targetId;
@@ -442,12 +526,14 @@ export const napcatPlugin = {
 
             console.log(`[NapCat] Sending media to ${targetType} ${targetId}: ${message}`);
 
-            try {
-                const result = await sendToNapCat(`${baseUrl}${endpoint}`, payload, token);
-                return { ok: true, result };
-            } catch (err: any) {
-                return { ok: false, error: err.message };
-            }
+            const deliveryKey = `${endpoint}\u0000${targetId}\u0000${message}`;
+            const result = await sendTextToNapCatOnce(
+                `${baseUrl}${endpoint}`,
+                payload,
+                token,
+                deliveryKey,
+            );
+            return toOutboundDeliveryResult(result, targetId);
         },
     },
     gateway: {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,11 @@
 // Global runtime reference for the plugin
 let _runtime: any;
 let _config: any = {};
+const activeGroupReplyContexts = new Map<string, {
+  senderId: string;
+  token: symbol;
+  expiresAt: number;
+}>();
 
 export function setNapCatRuntime(runtime: any) {
   _runtime = runtime;
@@ -19,4 +24,40 @@ export function getNapCatRuntime() {
 
 export function getNapCatConfig() {
   return _config || {};
+}
+
+export function beginNapCatGroupReplyContext(groupId: string, senderId: string): symbol | null {
+  const normalizedGroupId = String(groupId || "").trim();
+  const normalizedSenderId = String(senderId || "").trim();
+  if (!/^\d+$/.test(normalizedGroupId) || !/^\d+$/.test(normalizedSenderId)) {
+    return null;
+  }
+
+  const token = Symbol(`napcat-group-reply:${normalizedGroupId}`);
+  activeGroupReplyContexts.set(normalizedGroupId, {
+    senderId: normalizedSenderId,
+    token,
+    expiresAt: Date.now() + 10 * 60 * 1000,
+  });
+  return token;
+}
+
+export function endNapCatGroupReplyContext(groupId: string, token: symbol | null) {
+  if (!token) return;
+  const normalizedGroupId = String(groupId || "").trim();
+  const current = activeGroupReplyContexts.get(normalizedGroupId);
+  if (current?.token === token) {
+    activeGroupReplyContexts.delete(normalizedGroupId);
+  }
+}
+
+export function getNapCatGroupReplyMentionUser(groupId: string): string | undefined {
+  const normalizedGroupId = String(groupId || "").trim();
+  const current = activeGroupReplyContexts.get(normalizedGroupId);
+  if (!current) return undefined;
+  if (current.expiresAt <= Date.now()) {
+    activeGroupReplyContexts.delete(normalizedGroupId);
+    return undefined;
+  }
+  return current.senderId;
 }

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -6,7 +6,12 @@ import { appendFile, mkdir, stat } from "node:fs/promises";
 import { dirname, extname, resolve } from "node:path";
 import { buildNapCatMediaCq } from "./media.js";
 import { formatNapCatOutgoingText } from "./plainText.js";
-import { getNapCatRuntime, getNapCatConfig } from "./runtime.js";
+import {
+    beginNapCatGroupReplyContext,
+    endNapCatGroupReplyContext,
+    getNapCatRuntime,
+    getNapCatConfig,
+} from "./runtime.js";
 
 // Group name cache removed
 
@@ -1010,6 +1015,13 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
 
             console.log("[NapCat] Dispatcher created, methods:", Object.keys(dispatcher));
 
+            // Codex source-channel replies use the message tool, which bypasses
+            // the dispatcher deliver callback. Keep the triggering group sender
+            // available to the outbound adapter while this reply is running.
+            const groupReplyContextToken = isGroup
+                ? beginNapCatGroupReplyContext(groupId, senderId)
+                : null;
+
             // Dispatch the message to OpenClaw
             try {
                 await typingController.start();
@@ -1033,6 +1045,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             } finally {
                 typingController.stop();
                 markDispatchIdle?.();
+                endNapCatGroupReplyContext(groupId, groupReplyContextToken);
             }
             
             res.statusCode = 200;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -212,9 +212,10 @@ export async function sendToNapCat(
     throw lastErr;
 }
 
-async function buildNapCatMessageFromReply(
+export async function buildNapCatMessageFromReply(
     payload: { text?: string; mediaUrl?: string; mediaUrls?: string[]; audioAsVoice?: boolean },
-    config: any
+    config: any,
+    mentionUserId?: string
 ) {
     const text = formatNapCatOutgoingText(payload.text?.trim() || "", config);
     const mediaCandidates = [
@@ -228,9 +229,18 @@ async function buildNapCatMessageFromReply(
             .map((url) => buildNapCatMediaCq(url, config, payload.audioAsVoice === true))
     );
 
-    if (text && mediaSegments.length > 0) return `${text}\n${mediaSegments.join("\n")}`;
-    if (text) return text;
-    return mediaSegments.join("\n");
+    let message = "";
+    if (text && mediaSegments.length > 0) message = `${text}\n${mediaSegments.join("\n")}`;
+    else if (text) message = text;
+    else message = mediaSegments.join("\n");
+
+    if (!message) return "";
+
+    const normalizedMentionUserId = String(mentionUserId || "").trim();
+    if (/^\d+$/.test(normalizedMentionUserId)) {
+        return `[CQ:at,qq=${normalizedMentionUserId}] ${message}`;
+    }
+    return message;
 }
 
 function getContentTypeByPath(filePath: string): string {
@@ -912,7 +922,11 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         const isGroup = conversationId.startsWith("group:");
                         const targetId = isGroup ? conversationId.replace("group:", "") : conversationId.replace("private:", "");
                         const endpoint = isGroup ? "/send_group_msg" : "/send_private_msg";
-                        const message = await buildNapCatMessageFromReply(payload, config);
+                        const message = await buildNapCatMessageFromReply(
+                            payload,
+                            config,
+                            isGroup ? senderId : undefined
+                        );
                         if (!message) {
                             console.log("[NapCat] Skip empty reply payload");
                             return;
@@ -958,7 +972,11 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         const isGroup = conversationId.startsWith("group:");
                         const targetId = isGroup ? conversationId.replace("group:", "") : conversationId.replace("private:", "");
                         const endpoint = isGroup ? "/send_group_msg" : "/send_private_msg";
-                        const message = await buildNapCatMessageFromReply(payload, config);
+                        const message = await buildNapCatMessageFromReply(
+                            payload,
+                            config,
+                            isGroup ? senderId : undefined
+                        );
                         if (!message) {
                             console.log("[NapCat] Skip empty reply payload");
                             return;

--- a/tests/groupReplyMention.test.mjs
+++ b/tests/groupReplyMention.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildNapCatMessageFromReply } from "../dist/src/webhook.js";
+
+test("group replies mention the user who triggered the reply", async () => {
+  const message = await buildNapCatMessageFromReply(
+    { text: "你好呀" },
+    {},
+    "123456789",
+  );
+
+  assert.equal(message, "[CQ:at,qq=123456789] 你好呀");
+});
+
+test("private replies remain unchanged when no mention user is provided", async () => {
+  const message = await buildNapCatMessageFromReply(
+    { text: "私聊回复" },
+    {},
+  );
+
+  assert.equal(message, "私聊回复");
+});
+
+test("empty replies do not turn into mention-only messages", async () => {
+  const message = await buildNapCatMessageFromReply(
+    {},
+    {},
+    "123456789",
+  );
+
+  assert.equal(message, "");
+});
+
+test("invalid QQ identifiers are not rendered as CQ mentions", async () => {
+  const message = await buildNapCatMessageFromReply(
+    { text: "仍然发送正文" },
+    {},
+    "not-a-qq",
+  );
+
+  assert.equal(message, "仍然发送正文");
+});

--- a/tests/outboundReplyDelivery.test.mjs
+++ b/tests/outboundReplyDelivery.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { napcatPlugin } from "../dist/src/channel.js";
+import {
+  beginNapCatGroupReplyContext,
+  endNapCatGroupReplyContext,
+} from "../dist/src/runtime.js";
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Test server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+test("message-tool group replies mention the sender and return a delivery identity", async () => {
+  const requests = [];
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      requests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"status":"ok","data":{"message_id":24680}}');
+    });
+  });
+  const baseUrl = await listen(server);
+  const groupId = "829914483";
+  const token = beginNapCatGroupReplyContext(groupId, "997794945");
+
+  try {
+    const result = await napcatPlugin.outbound.sendText({
+      to: `group:${groupId}`,
+      text: "这次应该只发一次",
+      cfg: { channels: { napcat: { url: baseUrl } } },
+    });
+
+    assert.deepEqual(requests, [{
+      group_id: groupId,
+      message: "[CQ:at,qq=997794945] 这次应该只发一次",
+    }]);
+    assert.equal(result.channel, "napcat");
+    assert.equal(result.messageId, "24680");
+    assert.equal(result.chatId, groupId);
+  } finally {
+    endNapCatGroupReplyContext(groupId, token);
+    await close(server);
+  }
+});
+
+test("identical immediate outbound retries reuse the first delivery", async () => {
+  let requestCount = 0;
+  const server = createServer((req, res) => {
+    requestCount += 1;
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"status":"ok","data":{"message_id":13579}}');
+    });
+  });
+  const baseUrl = await listen(server);
+  const args = {
+    to: "group:123123123",
+    text: "不要重复",
+    cfg: { channels: { napcat: { url: baseUrl } } },
+  };
+
+  try {
+    const first = await napcatPlugin.outbound.sendText(args);
+    const second = await napcatPlugin.outbound.sendText(args);
+    assert.equal(requestCount, 1);
+    assert.equal(first.messageId, "13579");
+    assert.equal(second.messageId, "13579");
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

- mention the triggering user when replying in a group
- cover the actual outbound/message-tool delivery path
- return a standard delivery identity to prevent upper-layer resend behavior
- suppress identical outbound deliveries within 15 seconds as a safeguard
- keep transport retries disabled for non-idempotent message sends

## Testing

- npm test
- 8 tests passed