### PR TITLE
chore: 发布 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "devDependencies": {
         "@types/node": "^22.15.3",
         "openclaw": "^2026.4.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProperSAMA/openclaw-napcat-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ProperSAMA/openclaw-napcat-plugin/issues"
+  },
+  "homepage": "https://github.com/ProperSAMA/openclaw-napcat-plugin#readme",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## 内容\n- 将包版本更新为 1.0.6。\n- 添加 GitHub 仓库、Issues 和 README 主页元数据，使 npm 页面关联项目。\n\n## 验证\n- npm test\n- npm pack --dry-run --json