### PR TITLE
chore: 发布 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "devDependencies": {
         "@types/node": "^22.15.3",
         "openclaw": "^2026.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "repository": {


### PR DESCRIPTION
版本号 1.0.6 → 1.0.7

包含已合并的 PR #45 内容：
- fix: declare bundled napcat skill（在 openclaw.plugin.json 中声明内置 napcat-qq skill）

验证：npm test 8/8 通过