### PR TITLE
feat: QQ 消息表情回应与 1.0.8 发布准备

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 - 图片发送
 - 语音发送（WAV 等音频）
 - 群文件上传
+- QQ 消息表情回应（reaction）
+- 收到消息后自动添加确认表情（复用 OpenClaw `messages.ackReaction` 配置）
 - 白名单控制（只允许指定 QQ 号触发）
 - 入站消息日志记录
 - 私聊处理中显示“正在输入”
@@ -160,6 +162,29 @@ openclaw plugins enable napcat
 - 允许处理群消息
 - `groupWhitelist` 留空时不过滤群；填了之后只响应指定群
 - 但群里必须 **@ 机器人** 才会回复
+
+### 收到消息时添加表情回应
+
+NapCat 通道支持 OpenClaw 的统一确认表情配置。默认情况下，OpenClaw 会在机器人开始处理群聊 `@` 消息时添加 👀。如果希望显式配置，可以写成：
+
+```json
+{
+  "messages": {
+    "ackReaction": "👀",
+    "ackReactionScope": "group-mentions",
+    "removeAckAfterReply": false
+  }
+}
+```
+
+- `ackReaction` 可以填写单个 Unicode Emoji，也可以直接填写 QQ 数字表情 ID
+- `ackReactionScope` 支持 `group-mentions`、`group-all`、`direct`、`all`、`off`
+- `removeAckAfterReply: true` 会在回复流程结束后撤销确认表情
+- 如需关闭自动确认表情，将 `ackReactionScope` 设置为 `off`，或将 `ackReaction` 设置为空字符串
+- 被用户白名单、群白名单或群聊 `@` 规则过滤的消息不会添加确认表情
+- 只保证 NapCat 当前 QQ 表情回应接口支持的 Emoji 可用；不支持的 Emoji 会被跳过并记录警告
+
+NapCat 通道也支持 OpenClaw `message` 工具的 `react` 动作。未显式指定 `messageId` 时，会回应当前触发消息；`remove: true` 可撤销机器人自己的表情回应。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,17 @@ openclaw plugins enable napcat
 - `groupWhitelist` 留空时不过滤群；填了之后只响应指定群
 - 但群里必须 **@ 机器人** 才会回复
 
-### 收到消息时添加表情回应
+### 自动确认表情（👀）
 
-NapCat 通道支持 OpenClaw 的统一确认表情配置。默认情况下，OpenClaw 会在机器人开始处理群聊 `@` 消息时添加 👀。如果希望显式配置，可以写成：
+NapCat 通道支持 OpenClaw 的统一确认表情功能。机器人收到符合处理条件的消息后，可以立即添加一个 QQ 表情回应，让用户知道消息已经进入处理流程。
+
+默认行为是：
+
+- 使用 👀 作为确认表情
+- 仅在群聊中被 `@` 时添加
+- 回复完成后保留表情
+
+这些选项位于 OpenClaw 配置文件顶层的 `messages` 字段中，与 `channels.napcat` 同级：
 
 ```json
 {
@@ -178,11 +186,39 @@ NapCat 通道支持 OpenClaw 的统一确认表情配置。默认情况下，Ope
 ```
 
 - `ackReaction` 可以填写单个 Unicode Emoji，也可以直接填写 QQ 数字表情 ID
-- `ackReactionScope` 支持 `group-mentions`、`group-all`、`direct`、`all`、`off`
-- `removeAckAfterReply: true` 会在回复流程结束后撤销确认表情
-- 如需关闭自动确认表情，将 `ackReactionScope` 设置为 `off`，或将 `ackReaction` 设置为空字符串
+- `ackReactionScope` 控制在哪些消息上添加表情：
+  - `group-mentions`：仅群聊中被 `@` 的消息（默认）
+  - `group-all`：所有会被机器人处理的群消息
+  - `direct`：仅私聊消息
+  - `all`：群聊和私聊消息
+  - `off`：完全关闭
+- `removeAckAfterReply` 为 `true` 时，会在回复流程结束后撤销确认表情；默认为 `false`
 - 被用户白名单、群白名单或群聊 `@` 规则过滤的消息不会添加确认表情
 - 只保证 NapCat 当前 QQ 表情回应接口支持的 Emoji 可用；不支持的 Emoji 会被跳过并记录警告
+
+如需关闭该功能：
+
+```json
+{
+  "messages": {
+    "ackReactionScope": "off"
+  }
+}
+```
+
+也可以将 `ackReaction` 设置为空字符串来禁用确认表情。
+
+例如，改为收到消息时添加 👍，并在回复结束后自动撤销：
+
+```json
+{
+  "messages": {
+    "ackReaction": "👍",
+    "ackReactionScope": "group-mentions",
+    "removeAckAfterReply": true
+  }
+}
+```
 
 NapCat 通道也支持 OpenClaw `message` 工具的 `react` 动作。未显式指定 `messageId` 时，会回应当前触发消息；`remove: true` 可撤销机器人自己的表情回应。
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "napcat",
   "name": "NapCat QQ",
-  "version": "1.0.4",
+  "version": "1.0.8",
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "author": "ProperSAMA",
   "channels": ["napcat"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "devDependencies": {
         "@types/node": "^22.15.3",
-        "openclaw": "^2026.4.1",
+        "openclaw": "^2026.6.1",
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.4.1"
+        "openclaw": ">=2026.6.1"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "repository": {
@@ -33,7 +33,7 @@
     "onebot11"
   ],
   "peerDependencies": {
-    "openclaw": ">=2026.4.1"
+    "openclaw": ">=2026.6.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.3",
-    "openclaw": "^2026.4.1",
+    "openclaw": "^2026.6.1",
     "typescript": "^5.8.3"
   },
   "openclaw": {
@@ -51,7 +51,7 @@
     ],
     "install": {
       "npmSpec": "@propersama/openclaw-napcat",
-      "minHostVersion": ">=2026.4.1"
+      "minHostVersion": ">=2026.6.1"
     }
   },
   "publishConfig": {

--- a/skill/napcat-qq/SKILL.md
+++ b/skill/napcat-qq/SKILL.md
@@ -41,6 +41,15 @@ description: "为 openclaw 发送 QQ 消息（含图片/语音等媒体）时，
 
 10. 仅使用本插件的 API 完成发送，不要调用其他 QQ 发送途径。
 
+## QQ 消息表情回应
+
+- NapCat 通道支持 `message` 工具的 `react` 动作，可对 QQ 消息添加或撤销表情回应。
+- 回应当前触发消息时可以省略 `messageId`；回应其他消息时必须显式提供 `messageId`。
+- `emoji` 优先填写单个 Unicode Emoji；也可直接填写 QQ 数字表情 ID。
+- 只保证 QQ 表情回应面板支持的 Emoji 可用；不支持的 Emoji 不要反复重试。
+- 撤销机器人自己的回应时使用同一个 `emoji` 并传 `remove: true`。
+- 只在轻量确认、表达情绪且无需额外文字时使用，避免对同一条消息连续添加多个回应。
+
 # 入站上下文
 
 - 当消息来自 NapCat 入站通道时，当前上下文会提供机器人自己的 QQ 号字段：`SelfId`、`BotId`、`BotQQ`、`NapCatSelfId`。

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,8 +1,15 @@
 // Minimal NapCat Channel Implementation
 import path from "node:path";
 import { access, copyFile, mkdir, unlink } from "node:fs/promises";
+import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
+import {
+    jsonResult,
+    readReactionParams,
+    resolveReactionMessageId,
+} from "openclaw/plugin-sdk/channel-actions";
 import { buildNapCatMediaCq, isAudioMedia, resolveLocalFilePath } from "./media.js";
 import { formatNapCatOutgoingText } from "./plainText.js";
+import { resolveNapCatEmojiId } from "./reactions.js";
 import { getNapCatGroupReplyMentionUser, setNapCatConfig } from "./runtime.js";
 
 const recentTextDeliveries = new Map<string, {
@@ -196,6 +203,58 @@ function looksLikeNapCatTargetId(raw: string, normalized?: string): boolean {
     );
 }
 
+export const napcatMessageActions: ChannelMessageActionAdapter = {
+    supportsAction: ({ action }) => action === "react",
+    describeMessageTool: () => ({
+        actions: ["react"],
+        capabilities: [],
+        schema: null,
+    }),
+    handleAction: async ({ action, params, cfg, toolContext }) => {
+        if (action !== "react") {
+            throw new Error(`NapCat message action is not supported: ${action}`);
+        }
+
+        const messageId = resolveReactionMessageId({ args: params, toolContext });
+        if (messageId === undefined || messageId === null || !String(messageId).trim()) {
+            throw new Error(
+                "messageId required. Provide messageId explicitly or react to the current inbound message."
+            );
+        }
+        const { emoji, remove } = readReactionParams(params, {
+            removeErrorMessage: "Emoji is required to remove a NapCat reaction.",
+        });
+        const emojiId = resolveNapCatEmojiId(emoji);
+        const config = cfg.channels?.napcat || {};
+        const baseUrl = config.url || "http://127.0.0.1:15150";
+        const token = String(config.token || "").trim();
+
+        const result = await sendToNapCat(`${baseUrl}/set_msg_emoji_like`, {
+            message_id: String(messageId),
+            emoji_id: emojiId,
+            set: !remove,
+        }, token);
+
+        if (result?.status === "failed" || Number(result?.retcode || 0) !== 0) {
+            return jsonResult({
+                ok: false,
+                reason: "reaction_failed",
+                emoji,
+                emojiId,
+                hint: "NapCat rejected this reaction. Check the messageId and use an emoji supported by QQ. Do not retry unchanged.",
+            });
+        }
+
+        return jsonResult({
+            ok: true,
+            messageId: String(messageId),
+            emoji,
+            emojiId,
+            removed: remove,
+        });
+    },
+};
+
 export const napcatPlugin = {
     id: "napcat",
     meta: {
@@ -207,6 +266,7 @@ export const napcatPlugin = {
         chatTypes: ["direct", "group"],
         text: true,
         media: true,
+        reactions: true,
         blockStreaming: true
     },
     streaming: {
@@ -219,6 +279,7 @@ export const napcatPlugin = {
             hint: "private:<QQ号> / group:<群号> / session:napcat:private:<QQ号> / session:napcat:group:<群号>"
         }
     },
+    actions: napcatMessageActions,
     configSchema: {
         type: "object",
         properties: {

--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -1,0 +1,39 @@
+export function resolveNapCatEmojiId(value: string): string {
+    const normalized = value.trim().replace(/[\uFE0E\uFE0F]/g, "");
+    if (!normalized) {
+        throw new Error("Reaction emoji is required");
+    }
+    if (/^\d+$/.test(normalized)) {
+        return normalized;
+    }
+
+    const codePoints = Array.from(normalized);
+    if (codePoints.length !== 1 || !/^\p{Extended_Pictographic}$/u.test(normalized)) {
+        throw new Error(
+            `NapCat reactions require a numeric QQ emoji ID or one Unicode emoji; received ${JSON.stringify(normalized)}`
+        );
+    }
+
+    const codePoint = codePoints[0].codePointAt(0);
+    if (!codePoint) {
+        throw new Error(`Unable to resolve QQ emoji ID for ${JSON.stringify(normalized)}`);
+    }
+    return String(codePoint);
+}
+
+export function shouldSendNapCatAckReaction(params: {
+    scope?: string;
+    isGroup: boolean;
+    requireMention: boolean;
+    wasMentioned: boolean;
+}): boolean {
+    const scope = params.scope || "group-mentions";
+    if (scope === "off" || scope === "none") return false;
+    if (scope === "all") return true;
+    if (scope === "direct") return !params.isGroup;
+    if (scope === "group-all") return params.isGroup;
+    if (scope === "group-mentions") {
+        return params.isGroup && params.requireMention && params.wasMentioned;
+    }
+    return false;
+}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -4,8 +4,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createReadStream } from "node:fs";
 import { appendFile, mkdir, stat } from "node:fs/promises";
 import { dirname, extname, resolve } from "node:path";
+import { resolveAckReaction } from "openclaw/plugin-sdk/channel-feedback";
 import { buildNapCatMediaCq } from "./media.js";
 import { formatNapCatOutgoingText } from "./plainText.js";
+import { resolveNapCatEmojiId, shouldSendNapCatAckReaction } from "./reactions.js";
 import {
     beginNapCatGroupReplyContext,
     endNapCatGroupReplyContext,
@@ -97,6 +99,13 @@ const napcatHttpsAgent = new HttpsAgent({
 function isRetryableNapCatError(err: any): boolean {
     const code = String(err?.cause?.code || err?.code || "");
     return ["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "EPIPE", "UND_ERR_SOCKET", "ECONNABORTED"].includes(code);
+}
+
+function isNapCatFailedResponse(result: any): boolean {
+    return result?.status === "failed" ||
+        Number(result?.retcode || 0) !== 0 ||
+        result?.data?.status === "failed" ||
+        Number(result?.data?.retcode || 0) !== 0;
 }
 
 async function postJsonWithNodeHttp(
@@ -195,11 +204,16 @@ export async function sendToNapCat(
             console.log(`[NapCat] sendToNapCat success attempt ${attempt}/${maxAttempts} ${targetInfo} in ${elapsedMs}ms (connection=${connectionClose ? "close" : "keep-alive"})`);
 
             if (!res.bodyText) return { status: "ok" };
+            let parsed: any;
             try {
-                return JSON.parse(res.bodyText);
+                parsed = JSON.parse(res.bodyText);
             } catch {
                 return { status: "ok", raw: res.bodyText };
             }
+            if (isNapCatFailedResponse(parsed)) {
+                throw new Error(`NapCat API returned failure: ${res.bodyText.slice(0, 300)}`);
+            }
+            return parsed;
         } catch (err: any) {
             lastErr = err;
             const retryable = isRetryableNapCatError(err);
@@ -851,6 +865,40 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
             const routeAgentId = String(route.agentId || "").trim().toLowerCase();
             const effectiveAgentId = routeAgentId || configuredAgentId || "main";
             const sessionKey = `agent:${effectiveAgentId}:${baseSessionKey}`;
+            const ackReaction = resolveAckReaction(cfg, effectiveAgentId, {
+                channel: "napcat",
+                accountId: route.accountId,
+            });
+            const shouldSendAckReaction = Boolean(
+                ackReaction &&
+                shouldSendNapCatAckReaction({
+                    scope: cfg.messages?.ackReactionScope,
+                    isGroup,
+                    requireMention: isGroup && groupMentionOnly,
+                    wasMentioned,
+                })
+            );
+            let ackEmojiId: string | null = null;
+            if (shouldSendAckReaction) {
+                try {
+                    ackEmojiId = resolveNapCatEmojiId(ackReaction);
+                } catch (err) {
+                    console.warn(`[NapCat] Skipping unsupported ack reaction ${JSON.stringify(ackReaction)}:`, err);
+                }
+            }
+            const ackReactionPromise = ackEmojiId
+                ? sendToNapCat(`${config.url || "http://127.0.0.1:15150"}/set_msg_emoji_like`, {
+                    message_id: messageId,
+                    emoji_id: ackEmojiId,
+                    set: true,
+                }, String(config.token || "").trim(), { allowRetry: false }).then(
+                    () => true,
+                    (err) => {
+                        console.warn(`[NapCat] Failed to add ack reaction to message ${messageId}:`, err);
+                        return false;
+                    }
+                )
+                : null;
 
             // User requested to use session key as display name for consistency
             const sessionDisplayName = sessionKey;
@@ -1046,6 +1094,18 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                 typingController.stop();
                 markDispatchIdle?.();
                 endNapCatGroupReplyContext(groupId, groupReplyContextToken);
+                if (cfg.messages?.removeAckAfterReply && ackReactionPromise && ackEmojiId) {
+                    void ackReactionPromise.then((didAck) => {
+                        if (!didAck) return;
+                        return sendToNapCat(`${config.url || "http://127.0.0.1:15150"}/set_msg_emoji_like`, {
+                            message_id: messageId,
+                            emoji_id: ackEmojiId,
+                            set: false,
+                        }, String(config.token || "").trim(), { allowRetry: false }).catch((err) => {
+                            console.warn(`[NapCat] Failed to remove ack reaction from message ${messageId}:`, err);
+                        });
+                    });
+                }
             }
             
             res.statusCode = 200;

--- a/tests/reactions.test.mjs
+++ b/tests/reactions.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { napcatMessageActions } from "../dist/src/channel.js";
+import {
+  resolveNapCatEmojiId,
+  shouldSendNapCatAckReaction,
+} from "../dist/src/reactions.js";
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Test server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+test("converts a Unicode emoji to the QQ reaction emoji ID", () => {
+  assert.equal(resolveNapCatEmojiId("👀"), "128064");
+  assert.equal(resolveNapCatEmojiId("👍"), "128077");
+  assert.equal(resolveNapCatEmojiId("❤️"), "10084");
+  assert.equal(resolveNapCatEmojiId("128064"), "128064");
+});
+
+test("rejects composite emoji that cannot map to one QQ emoji ID", () => {
+  assert.throws(() => resolveNapCatEmojiId("👨‍💻"), /numeric QQ emoji ID or one Unicode emoji/);
+  assert.throws(() => resolveNapCatEmojiId("A"), /numeric QQ emoji ID or one Unicode emoji/);
+});
+
+test("uses OpenClaw ack reaction scope semantics", () => {
+  const base = { isGroup: true, requireMention: true, wasMentioned: true };
+  assert.equal(shouldSendNapCatAckReaction({ ...base, scope: "group-mentions" }), true);
+  assert.equal(shouldSendNapCatAckReaction({ ...base, wasMentioned: false, scope: "group-mentions" }), false);
+  assert.equal(shouldSendNapCatAckReaction({ ...base, scope: "group-all" }), true);
+  assert.equal(shouldSendNapCatAckReaction({ ...base, scope: "off" }), false);
+  assert.equal(shouldSendNapCatAckReaction({ ...base, isGroup: false, scope: "direct" }), true);
+});
+
+test("react action targets the current inbound message and supports removal", async () => {
+  const requests = [];
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      requests.push({
+        url: req.url,
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"status":"ok","data":{"result":true}}');
+    });
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await napcatMessageActions.handleAction({
+      action: "react",
+      params: { emoji: "👀", remove: true },
+      cfg: { channels: { napcat: { url: baseUrl } } },
+      toolContext: { currentMessageId: "24680" },
+    });
+
+    assert.deepEqual(requests, [{
+      url: "/set_msg_emoji_like",
+      body: {
+        message_id: "24680",
+        emoji_id: "128064",
+        set: false,
+      },
+    }]);
+    assert.match(result.content[0].text, /"ok": true/);
+  } finally {
+    await close(server);
+  }
+});
+
+test("does not intercept the core send action", () => {
+  assert.equal(napcatMessageActions.supportsAction({ action: "react" }), true);
+  assert.equal(napcatMessageActions.supportsAction({ action: "send" }), false);
+});

--- a/tests/sendToNapCat.test.mjs
+++ b/tests/sendToNapCat.test.mjs
@@ -77,3 +77,27 @@ test("idempotent NapCat calls keep transient retries enabled", async () => {
     await close(server);
   }
 });
+
+test("NapCat failed responses are not treated as successful JSON responses", async () => {
+  const server = createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"status":"failed","retcode":200,"message":"msg not found"}');
+    });
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    await assert.rejects(
+      sendToNapCat(`${baseUrl}/set_msg_emoji_like`, {
+        message_id: "999999",
+        emoji_id: "128064",
+        set: true,
+      }, undefined, { allowRetry: false }),
+      /NapCat API returned failure/,
+    );
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## 概要

为 NapCat QQ 通道新增消息表情回应能力，并准备发布 `@propersama/openclaw-napcat@1.0.8`。

## 主要改动

- 支持 OpenClaw `message` 工具的 `react` 动作
  - 可回应指定 QQ 消息
  - 省略 `messageId` 时回应当前触发消息
  - 支持 `remove: true` 撤销机器人自己的表情回应
- 支持自动确认表情
  - 复用 `messages.ackReaction`、`ackReactionScope` 和 `removeAckAfterReply`
  - 默认在群聊被 `@` 时添加 👀
  - 支持 Unicode Emoji 和 QQ 数字表情 ID
- 加强 NapCat API 错误处理
  - HTTP 200 但返回 `status: "failed"` 或非零 `retcode` 时不再误报成功
  - 普通 `send` 动作不会被 reaction adapter 截获
- 完善 README 和 bundled `napcat-qq` skill 使用说明
- 版本统一升级至 `1.0.8`
  - `package.json`
  - `package-lock.json`
  - `openclaw.plugin.json`
- 最低 OpenClaw 版本调整为 `2026.6.1`
  - reaction 所需的 `channel-actions`、`channel-feedback`、`channel-contract` 导出已通过 npm 历史包内容验证

## 行为变化

`sendToNapCat` 现在会将 NapCat 返回的失败响应视为错误。该行为适用于所有通过此封装发起的 NapCat API 调用，不仅限于表情回应，避免调用方在 OneBot 返回失败时继续按成功路径执行。

## 验证

- `npm test`：14/14 通过
- `npm pack --dry-run --json`：通过
  - 包版本：`1.0.8`
  - 34 个文件
  - 包含 reaction 构建产物、README、插件清单和 bundled skill
  - 排除不应发布的联系人搜索脚本
- `git diff --check`：通过
- 已在本机 NapCat QQ 环境验证自动 👀 表情回应

## 发布说明

本 PR 合并后即可执行 npm publish。依赖树现有的 npm audit 告警未在本 PR 中自动修复，以避免夹带无关依赖升级。
