### PR TITLE
fix: outbound 投递/发送落入正确的 canonical session（v1.0.11）

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -50,6 +50,12 @@
             "description": "Stream replies as incremental QQ messages instead of waiting for the final combined response",
             "default": false
           },
+          "enable_progress_messages": {
+            "type": "boolean",
+            "title": "Enable Progress Messages",
+            "description": "Send assistant intermediate progress (commentary) messages to QQ as well, throttled to 1 per 3s per conversation",
+            "default": false
+          },
           "plainTextMode": {
             "type": "boolean",
             "title": "Plain Text Mode",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.8",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propersama/openclaw-napcat",
-      "version": "1.0.8",
+      "version": "1.0.11",
       "devDependencies": {
         "@types/node": "^22.15.3",
         "openclaw": "^2026.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propersama/openclaw-napcat",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": false,
   "description": "QQ chat channel plugin for OpenClaw via NapCat (OneBot 11)",
   "repository": {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -316,6 +316,12 @@ export const napcatPlugin = {
                 description: "Stream replies as incremental QQ messages instead of waiting for the final combined response",
                 default: false
             },
+            enable_progress_messages: {
+                type: "boolean",
+                title: "Enable Progress Messages",
+                description: "把 assistant 工作过程中的中间进度消息也发送到 QQ（throttled to 1 per 3s per conversation）",
+                default: false
+            },
             plainTextMode: {
                 type: "boolean",
                 title: "Plain Text Mode",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { access, copyFile, mkdir, unlink } from "node:fs/promises";
 import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
+import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk/core";
 import {
     jsonResult,
     readReactionParams,
@@ -203,6 +204,44 @@ function looksLikeNapCatTargetId(raw: string, normalized?: string): boolean {
     );
 }
 
+function parseNapCatSessionTarget(raw: string): { chatType: "direct" | "group"; peerId: string } | null {
+    const trimmed = String(raw ?? "").trim();
+    if (!trimmed) return null;
+    const withoutProvider = trimmed.replace(/^napcat:/i, "");
+    const match = withoutProvider.match(/^(?:session:napcat:)?(private|group):(\d+)$/i);
+    if (!match) return null;
+    return {
+        chatType: match[1].toLowerCase() === "group" ? "group" : "direct",
+        peerId: match[2],
+    };
+}
+
+const inferNapCatTargetChatType: NonNullable<ChannelMessagingAdapter["inferTargetChatType"]> = ({ to }) => {
+    return parseNapCatSessionTarget(to)?.chatType;
+};
+
+const resolveNapCatOutboundSessionRoute: NonNullable<ChannelMessagingAdapter["resolveOutboundSessionRoute"]> = (params) => {
+    const parsed = parseNapCatSessionTarget(params.target);
+    if (!parsed) return null;
+    const agentId = String(params.agentId || "").trim().toLowerCase() || "main";
+    const conversationType = parsed.chatType === "group" ? "group" : "private";
+    // Must match the inbound canonical session key built in webhook.ts:
+    // `agent:${agentId}:session:napcat:(private|group):${id}`
+    const sessionKey = `agent:${agentId}:session:napcat:${conversationType}:${parsed.peerId}`;
+    const conversationId = `${conversationType}:${parsed.peerId}`;
+    return {
+        sessionKey,
+        // SDK semantics: session key minus any thread suffix (none for NapCat).
+        baseSessionKey: sessionKey,
+        peer: { kind: parsed.chatType, id: parsed.peerId },
+        chatType: parsed.chatType,
+        from: `napcat:${conversationId}`,
+        // Core uses route.to as the delivery target handed to outbound.sendText,
+        // which parses `private:<id>` / `group:<id>` (no `napcat:` prefix).
+        to: conversationId,
+    };
+};
+
 export const napcatMessageActions: ChannelMessageActionAdapter = {
     supportsAction: ({ action }) => action === "react",
     describeMessageTool: () => ({
@@ -255,6 +294,16 @@ export const napcatMessageActions: ChannelMessageActionAdapter = {
     },
 };
 
+const napcatMessaging: ChannelMessagingAdapter = {
+    normalizeTarget: normalizeNapCatTarget,
+    inferTargetChatType: inferNapCatTargetChatType,
+    resolveOutboundSessionRoute: resolveNapCatOutboundSessionRoute,
+    targetResolver: {
+        looksLikeId: looksLikeNapCatTargetId,
+        hint: "private:<QQ号> / group:<群号> / session:napcat:private:<QQ号> / session:napcat:group:<群号>"
+    }
+};
+
 export const napcatPlugin = {
     id: "napcat",
     meta: {
@@ -272,13 +321,7 @@ export const napcatPlugin = {
     streaming: {
         blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 }
     },
-    messaging: {
-        normalizeTarget: normalizeNapCatTarget,
-        targetResolver: {
-            looksLikeId: looksLikeNapCatTargetId,
-            hint: "private:<QQ号> / group:<群号> / session:napcat:private:<QQ号> / session:napcat:group:<群号>"
-        }
-    },
+    messaging: napcatMessaging,
     actions: napcatMessageActions,
     configSchema: {
         type: "object",

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -992,6 +992,9 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                             console.log("[NapCat] Commentary payload throttled, skipped");
                             return;
                         }
+                        if (payload?.isCommentary === true && typeof payload.text === "string" && payload.text.trim()) {
+                            payload = { ...payload, text: `⏳ ${payload.text}` };
+                        }
                         typingController.stop();
                         console.log("[NapCat] Reply to deliver:", JSON.stringify(payload).substring(0, 100));
                         // Actually send the message via NapCat API
@@ -1045,6 +1048,9 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         if (payload?.isCommentary === true && !shouldDeliverCommentaryPayload(conversationId)) {
                             console.log("[NapCat] Commentary payload throttled, skipped");
                             return;
+                        }
+                        if (payload?.isCommentary === true && typeof payload.text === "string" && payload.text.trim()) {
+                            payload = { ...payload, text: `⏳ ${payload.text}` };
                         }
                         typingController.stop();
                         console.log("[NapCat] Reply to deliver:", JSON.stringify(payload).substring(0, 100));

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -26,6 +26,28 @@ function isNapCatStreamingModeEnabled(config: any): boolean {
     return config?.streaming_mode === true;
 }
 
+function isNapCatProgressMessagesEnabled(config: any): boolean {
+    return config?.enable_progress_messages === true;
+}
+
+// Throttle assistant commentary (progress) messages so long multi-tool tasks
+// do not flood QQ. Final (non-commentary) payloads are never throttled.
+const COMMENTARY_MIN_INTERVAL_MS = 3000;
+const commentaryLastSentAt = new Map<string, number>();
+
+function shouldDeliverCommentaryPayload(conversationId: string): boolean {
+    const now = Date.now();
+    const last = commentaryLastSentAt.get(conversationId) || 0;
+    if (now - last < COMMENTARY_MIN_INTERVAL_MS) return false;
+    commentaryLastSentAt.set(conversationId, now);
+    if (commentaryLastSentAt.size > 100) {
+        for (const [key, ts] of commentaryLastSentAt) {
+            if (now - ts > 10 * 60 * 1000) commentaryLastSentAt.delete(key);
+        }
+    }
+    return true;
+}
+
 function isNapCatPrivateTypingEnabled(config: any): boolean {
     return config?.enablePrivateTypingStatus !== false;
 }
@@ -966,6 +988,10 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                     responsePrefixContextProvider: () => ({}),
                     humanDelay: 0,
                     deliver: async (payload) => {
+                        if (payload?.isCommentary === true && !shouldDeliverCommentaryPayload(conversationId)) {
+                            console.log("[NapCat] Commentary payload throttled, skipped");
+                            return;
+                        }
                         typingController.stop();
                         console.log("[NapCat] Reply to deliver:", JSON.stringify(payload).substring(0, 100));
                         // Actually send the message via NapCat API
@@ -1016,6 +1042,10 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                     responsePrefixContextProvider: () => ({}),
                     humanDelay: 0,
                     deliver: async (payload) => {
+                        if (payload?.isCommentary === true && !shouldDeliverCommentaryPayload(conversationId)) {
+                            console.log("[NapCat] Commentary payload throttled, skipped");
+                            return;
+                        }
                         typingController.stop();
                         console.log("[NapCat] Reply to deliver:", JSON.stringify(payload).substring(0, 100));
                         // Actually send the message via NapCat API
@@ -1081,6 +1111,7 @@ export async function handleNapCatWebhook(req: IncomingMessage, res: ServerRespo
                         replyOptions: {
                             ...dispatcherReplyOptions,
                             disableBlockStreaming: !isNapCatStreamingModeEnabled(config),
+                            commentaryPayloadsEnabled: isNapCatProgressMessagesEnabled(config),
                         },
                     });
                 } catch (err) {

--- a/tests/outboundSessionRoute.test.mjs
+++ b/tests/outboundSessionRoute.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { napcatPlugin } from "../dist/src/channel.js";
+
+const messaging = napcatPlugin.messaging;
+
+test("inferTargetChatType detects direct chats from private targets", () => {
+  assert.equal(messaging.inferTargetChatType({ to: "private:123456" }), "direct");
+  assert.equal(messaging.inferTargetChatType({ to: "napcat:private:123456" }), "direct");
+  assert.equal(
+    messaging.inferTargetChatType({ to: "session:napcat:private:123456" }),
+    "direct",
+  );
+  assert.equal(
+    messaging.inferTargetChatType({ to: "napcat:session:napcat:private:123456" }),
+    "direct",
+  );
+});
+
+test("inferTargetChatType detects group chats from group targets", () => {
+  assert.equal(messaging.inferTargetChatType({ to: "group:987654" }), "group");
+  assert.equal(messaging.inferTargetChatType({ to: "napcat:group:987654" }), "group");
+  assert.equal(
+    messaging.inferTargetChatType({ to: "session:napcat:group:987654" }),
+    "group",
+  );
+});
+
+test("inferTargetChatType returns undefined for bare QQ numbers and unknown targets", () => {
+  assert.equal(messaging.inferTargetChatType({ to: "123456" }), undefined);
+  assert.equal(messaging.inferTargetChatType({ to: "napcat:123456" }), undefined);
+  assert.equal(messaging.inferTargetChatType({ to: "somebody" }), undefined);
+  assert.equal(messaging.inferTargetChatType({ to: "" }), undefined);
+});
+
+test("resolveOutboundSessionRoute builds canonical private session keys", () => {
+  const route = messaging.resolveOutboundSessionRoute({
+    cfg: {},
+    agentId: "main",
+    target: "session:napcat:private:123456",
+  });
+  assert.deepEqual(route, {
+    sessionKey: "agent:main:session:napcat:private:123456",
+    baseSessionKey: "agent:main:session:napcat:private:123456",
+    peer: { kind: "direct", id: "123456" },
+    chatType: "direct",
+    from: "napcat:private:123456",
+    to: "private:123456",
+  });
+});
+
+test("resolveOutboundSessionRoute builds canonical group session keys", () => {
+  const route = messaging.resolveOutboundSessionRoute({
+    cfg: {},
+    agentId: "main",
+    target: "napcat:session:napcat:group:987654",
+  });
+  assert.equal(route.sessionKey, "agent:main:session:napcat:group:987654");
+  assert.equal(route.baseSessionKey, "agent:main:session:napcat:group:987654");
+  assert.deepEqual(route.peer, { kind: "group", id: "987654" });
+  assert.equal(route.chatType, "group");
+  assert.equal(route.from, "napcat:group:987654");
+  assert.equal(route.to, "group:987654");
+});
+
+test("resolveOutboundSessionRoute accepts short private/group targets without the session prefix", () => {
+  const direct = messaging.resolveOutboundSessionRoute({
+    cfg: {},
+    agentId: "main",
+    target: "private:123456",
+  });
+  assert.equal(direct.sessionKey, "agent:main:session:napcat:private:123456");
+  assert.equal(direct.chatType, "direct");
+
+  const group = messaging.resolveOutboundSessionRoute({
+    cfg: {},
+    agentId: "main",
+    target: "group:987654",
+  });
+  assert.equal(group.sessionKey, "agent:main:session:napcat:group:987654");
+  assert.equal(group.chatType, "group");
+});
+
+test("resolveOutboundSessionRoute normalizes the agent id like the inbound webhook", () => {
+  const route = messaging.resolveOutboundSessionRoute({
+    cfg: {},
+    agentId: " Main ",
+    target: "private:123456",
+  });
+  assert.equal(route.sessionKey, "agent:main:session:napcat:private:123456");
+});
+
+test("resolveOutboundSessionRoute returns null for bare QQ numbers so the core fallback handles them", () => {
+  assert.equal(
+    messaging.resolveOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "123456",
+    }),
+    null,
+  );
+  assert.equal(
+    messaging.resolveOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "napcat:123456",
+    }),
+    null,
+  );
+  assert.equal(
+    messaging.resolveOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "not-a-target",
+    }),
+    null,
+  );
+});


### PR DESCRIPTION
## 问题

cron 投递与 message 工具向 `napcat:session:napcat:private:<qq>` 这类目标发送时，OpenClaw 核心造出了畸形 session key：

```
agent:main:napcat:group:session:napcat:private:997794945
```

（把整串 `session:napcat:private:<qq>` 当成 peer ID，且 chatType 兜底误判为 group。）消息投递本身正常，但 outbound 记录被挂进了错误的 session，和 inbound 消息不在同一个会话里。

## 根因

核心 SDK 的 `ChannelMessagingAdapter` 提供了 `resolveOutboundSessionRoute` / `inferTargetChatType` 钩子（bundled 的 LINE/Discord/Telegram 插件都实现了），本插件只注册了 `normalizeTarget`。核心走内置 fallback：`detectTargetKind` 兜底判 group → `stripKindPrefix` 不认识 `session:` 前缀 → 原样拼出畸形 key。核心侧设计完整，无需上游改动。

## 修复

- 新增 `parseNapCatSessionTarget` helper：识别 `[napcat:][session:napcat:](private|group):<id>` 各形态
- `inferTargetChatType`：private → direct，group → group
- `resolveOutboundSessionRoute`：手工构造 route，sessionKey 与 inbound（webhook.ts）**逐字符一致**：`agent:<agentId>:session:napcat:(private|group):<id>`
  - 特意不用核心 `buildChannelOutboundSessionRoute` helper：其 dmScope=main 会把私聊折叠成 `agent:<id>:main`，与本插件 inbound 格式不符
  - 裸 QQ 号等未识别形态返回 null，走核心 fallback
- `normalizeTarget` / `targetResolver` 行为不变
- messaging 块抽为 `napcatMessaging: ChannelMessagingAdapter`（修复 tsc TS2742，同时获得编译期类型校验）

## 测试

- 新增 `tests/outboundSessionRoute.test.mjs`（8 用例：private/group × 带不带前缀、agentId 归一化、裸 QQ fallback）
- `npm test` 22/22 全绿
- 本机部署实测：发送后 session store 中 canonical key 正常更新，畸形 key 不再被写入 ✅

## 包含的其他提交

- `b1792d7` / `1ab6267`：进度消息（⏳）功能，此前只在本地未推送，随本 PR 一并合入
- `896b0c0`：版本号 1.0.10 → 1.0.11（npm 上最新发布为 1.0.8，1.0.9/1.0.10 未发布）

✨ 此代码修改由 @ProperSAMA 的 AI 智能助理 Lumi 完成！